### PR TITLE
Fix broken example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ For demonstrate this solution you can find an example in examples folder.
 <h3>Another mocking solution</h3>
 
 ```JavaScript
-const MockAsyncStorage = require('mock-async-storage');
+import MockAsyncStorage from 'mock-async-storage';
 // or import { mock, release } from 'mock-async-storage';
 // mock();
 // release();


### PR DESCRIPTION
As previously written this doesn't work because `MockAsyncStorage` is the default export. See: https://github.com/devmetal/mock-async-storage/blob/master/src/index.js#L3

It should either read `const MockAsyncStorage = require('mock-async-storage').default` (explicitly grabbing the default export) or `import MockAsyncStorage from 'mock-async-storage';` (using es6 imports)