### PR TITLE
Makes getItem's default resolved value null

### DIFF
--- a/src/__tests__/mockAsyncStorage.spec.js
+++ b/src/__tests__/mockAsyncStorage.spec.js
@@ -16,6 +16,11 @@ describe('Async Storage Tests', () => {
     expect(foo).toEqual('bar')
   })
 
+  it('#getItem returns null if item not in store', async () => {
+    const foo = await storage.getItem('baz')
+    expect(foo).toEqual(null)
+  })
+
   it('#removeItem', async () => {
     await storage.removeItem('foo')
     const store = storage.getStore()

--- a/src/mockAsyncStorage.js
+++ b/src/mockAsyncStorage.js
@@ -37,7 +37,7 @@ class AsyncDict<K, V> {
   }
 
   async getItem (k: K, cb: ?ErrBack<V>): Promise<?V> {
-    const val = this.store.get(k)
+    const val = this.store.get(k) || null
     if (cb) cb(null, val)
     return val
   }


### PR DESCRIPTION
Fixes issue https://github.com/devmetal/mock-async-storage/issues/17