### PR TITLE
Fix multiGet's value for unknown keys to null

### DIFF
--- a/src/__tests__/mockAsyncStorage.spec.js
+++ b/src/__tests__/mockAsyncStorage.spec.js
@@ -121,10 +121,10 @@ describe('Async Storage Tests', () => {
 
   it('#multiGet and the callback', async () => {
     const cb = jest.fn()
-    const values = await storage.multiGet(['foo', 'bar'], cb)
+    const values = await storage.multiGet(['foo', 'bar', 'baz'], cb)
 
-    expect(values).toEqual([['foo', 'foo'], ['bar', 'bar']])
-    expect(cb).toBeCalledWith(null, [['foo', 'foo'], ['bar', 'bar']])
+    expect(values).toEqual([['foo', 'foo'], ['bar', 'bar'], ['baz', null]])
+    expect(cb).toBeCalledWith(null, [['foo', 'foo'], ['bar', 'bar'], ['baz', null]])
   })
 
   it('#multiSet and the callback', async () => {

--- a/src/mockAsyncStorage.js
+++ b/src/mockAsyncStorage.js
@@ -64,8 +64,7 @@ class AsyncDict<K, V> {
   }
 
   async multiGet (keys: Array<K>, cb: ?ErrBack<Entries<K, V>>): Promise<Entries<K, V>> {
-    const entries = Array.from(this.store.entries())
-    const requested = entries.filter(([k]) => keys.includes(k))
+    const requested = keys.map(k => [k, this.store.get(k) || null])
     if (cb) cb(null, requested)
     return requested
   }


### PR DESCRIPTION
Similar to #18, `multiGet` should return `null` for unknown keys.